### PR TITLE
Shopify API Client: update to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:latest
+FROM python:3-alpine
 
-RUN apk update && apk add python3 && mkdir -p /opt/shopify-analytics
-COPY . /opt/shopify-analytics
-
+RUN mkdir -p /opt/
 WORKDIR /opt/shopify-analytics
+COPY ./requirements.txt /opt/shopify-analytics
 RUN cd /opt/shopify-analytics && pip3 install -r requirements.txt
+COPY ./get_orders.py /opt/shopify-analytics/
 
 ENTRYPOINT python3 get_orders.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3-alpine
 
-RUN mkdir -p /opt/
 WORKDIR /opt/shopify-analytics
-COPY ./requirements.txt /opt/shopify-analytics
-RUN cd /opt/shopify-analytics && pip3 install -r requirements.txt
-COPY ./get_orders.py /opt/shopify-analytics/
+COPY ./requirements.txt ./
+RUN pip3 install -r requirements.txt
+COPY ./get_orders.py ./
 
 ENTRYPOINT python3 get_orders.py

--- a/get_orders.py
+++ b/get_orders.py
@@ -56,7 +56,7 @@ def set_order_id(order):
     return order
 
 shop_url = "https://{}.myshopify.com/admin".format(os.environ['SHOPIFY_SHOP_NAME'])
-session = shopify.Session(shop_url, "2020-10", os.environ['SHOPIFY_PASSWORD'])
+session = shopify.Session(shop_url, "2021-01", os.environ['SHOPIFY_PASSWORD'])
 shopify.ShopifyResource.activate_session(session)
 
 days_ago = 0 if 'DAYS_AGO' not in os.environ else int(os.environ['DAYS_AGO'])

--- a/get_orders.py
+++ b/get_orders.py
@@ -46,22 +46,18 @@ def get_all_orders(orders_getter, limit=50):
     and pages through it until there are no orders left.
     This returns a generator so that orders can be processed as a stream.
     """
-    page = 1
-    orders = orders_getter(page=page, limit=limit)
+    orders = shopify.PaginatedIterator(orders_getter(limit=limit))
 
-    while orders:
-        yield from orders
-        page += 1
-        orders = orders_getter(page=page, limit=limit)
+    for page in orders:
+        yield from page
 
 def set_order_id(order):
     order['_id'] = order['id']
     return order
 
-shop_url = "https://{}:{}@{}.myshopify.com/admin".format(os.environ['SHOPIFY_API_KEY'],
-                                                         os.environ['SHOPIFY_PASSWORD'],
-                                                         os.environ['SHOPIFY_SHOP_NAME'])
-shopify.ShopifyResource.set_site(shop_url)
+shop_url = "https://{}.myshopify.com/admin".format(os.environ['SHOPIFY_SHOP_NAME'])
+session = shopify.Session(shop_url, "2020-10", os.environ['SHOPIFY_PASSWORD'])
+shopify.ShopifyResource.activate_session(session)
 
 days_ago = 0 if 'DAYS_AGO' not in os.environ else int(os.environ['DAYS_AGO'])
 minutes_ago = 0 if 'MINUTES_AGO' not in os.environ else int(os.environ['MINUTES_AGO'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ iso8601==0.1.12
 isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
-pyactiveresource==2.1.2
+pyactiveresource==2.2.0
 pymongo==3.6.0
 PyYAML==3.12
-ShopifyAPI==2.6.0
+ShopifyAPI==8.2.0
 six==1.11.0
 wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 pyactiveresource==2.2.0
 pymongo==3.6.0
-PyYAML==3.12
+PyYAML==5.4.1
 ShopifyAPI==8.2.0
 six==1.11.0
 wrapt==1.10.11


### PR DESCRIPTION
The old pagination method is being deprecated by shopify so we have to
keep up with the times.
                                                    
New client doesn't appear to need the API key anymore, just the password.

Note: also includes refreshing the Dockerfile and dealing with a security vuln
on a dependency.
                          
Closes iFixit/ifixit#34863