### PR TITLE
Shopify-analytics: setup basic ECR push workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Shopify Analytics Deploy
+
+on:
+  push:
+    branches: [ master ]
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  ECR_IMAGE_REPO: "884681002735.dkr.ecr.us-east-1.amazonaws.com/shopify-analytics"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Image
+        run: docker build -t ${{ env.ECR_IMAGE_REPO }}:${{ github.sha }} --label org.label-schema.name="shopify-analytics" .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   ECR_IMAGE_REPO: "884681002735.dkr.ecr.us-east-1.amazonaws.com/shopify-analytics"
+  DEPLOY_IAM_ROLE: "arn:aws:iam::884681002735:role/github_actions/github-actions-role"
 
 jobs:
   deploy:
@@ -18,3 +19,15 @@ jobs:
 
       - name: Build Image
         run: docker build -t ${{ env.ECR_IMAGE_REPO }}:${{ github.sha }} --label org.label-schema.name="shopify-analytics" .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.DEPLOY_IAM_ROLE }}
+          aws-region: us-east-1
+
+      - name: ECR login
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push to ECR
+        run: docker push ${{ env.ECR_IMAGE_REPO }}:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Shopify Analytics Deploy
 
+permissions:
+  id-token: write # Required to allow the JWT to be requested from GitHub's OIDC provider
+  contents: read # Required for actions/checkout
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Add a basic workflow to build and push this image to ECR.

This workflow currently replaces the version in GoCD:
![image](https://github.com/iFixit/shopify-analytics/assets/6876047/3e3437d3-d914-4ffb-8e57-e6e4ffca2ddb)
but is predicated on IAM permissions here: https://github.com/iFixit/server-templates/pull/4260

This accomplishes the main outcome (build and push from Actions instead of GoCD) but is not feature complete. In a few followups, we may want to set up [automatic image updates](https://github.com/iFixit/airflow-dags/blob/master/update-image.py) in the Airflow DAGs repo, to get full end-to-end CD. 

But this accomplishes a replacement of the current build pipeline.

qa_req 0

Ref: https://github.com/iFixit/server-templates/issues/3854